### PR TITLE
Always use the main module for version checking

### DIFF
--- a/persona4golden.asl
+++ b/persona4golden.asl
@@ -15,7 +15,7 @@ state("P4G", "Legacy Steam")
 
 init
 {
-	switch (modules.First().ModuleMemorySize)
+	switch (game.MainModule.ModuleMemorySize)
 	{	
 		case 913334272:
 		case 884142080: 


### PR DESCRIPTION
`modules.First()` sometimes returns `ntdll.dll` instead of the game exe (at least on my system), using `game.MainModule` should ensure it's actually always the game exe